### PR TITLE
Fix for folders included in glob matches

### DIFF
--- a/.github/workflows/packfile.yml
+++ b/.github/workflows/packfile.yml
@@ -96,8 +96,9 @@ jobs:
       id: glob
       uses: tj-actions/glob@v13
       with:
-        files: ${{ inputs.paths }}
         files-separator: ${{ inputs.paths_separator }}
+        files: ${{ inputs.paths }}
+        match-directories: false
         separator: "\n"
     - name: Generate options
       id: opts


### PR DESCRIPTION
Folders are included by default since [[tj-actions/glob@v13](https://github.com/tj-actions/glob)](https://github.com/tj-actions/glob/tree/v13)